### PR TITLE
Removeal of threading.local causing multithreading issues because the co...

### DIFF
--- a/balanced/config.py
+++ b/balanced/config.py
@@ -1,5 +1,3 @@
-import threading
-
 from balanced import __version__
 from balanced.utils import urljoin
 
@@ -8,7 +6,7 @@ def _make_user_agent():
     return 'balanced-python/' + __version__
 
 
-class Config(threading.local, object):
+class Config(object):
 
     def __init__(self):
         super(Config, self).__init__()


### PR DESCRIPTION
...nfig.api_key_secret would be set to None each time

I understand the idea of having the config be a threading.local but in most use cases, mine included, I have had no real need to switch between multiple api keys. Of course I could be wrong and switching between different market places is more common place than I think then this can be ignored. 

Included a test that runs two threads and saves the current API secret and then makes sure they are the same. 

Based on the use case in: https://github.com/balanced/balanced-python/issues/5
And my use case this fixes it.

It could also make sense to maybe have a second config something along the lines of `async_config` or something or another so that it is more explicit to the user that this config will be the same across threads and should be immutable to some extent. Or have the config work similarly to python-boto and either read from the environment or from a special `.balanced` home directory file with the api key in it.  The permissions on this file can be checked to make sure it is somewhat secured from others reading it much the same as a ssh key file.
