### PR TITLE
Update requests dep version in req.txt; #26

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ certifi==0.0.8
 chardet==1.0.1
 simplejson==2.3.2
 iso8601==0.1.4
-requests>=0.11, <0.12
+requests>=0.11, <0.14.2
 mock>=0.8,<0.9


### PR DESCRIPTION
This works around a problem on GAE with client certificates. We 
don't upgrade to the latest requests because we depend on internals
(see munge_request in http_client.py).
