### PR TITLE
Fixed incorrect method name from v1 to v1.1 changeover

### DIFF
--- a/scenarios/card_show/definition.mako
+++ b/scenarios/card_show/definition.mako
@@ -1,1 +1,1 @@
-balanced.Card().find()
+balanced.Card().get()

--- a/scenarios/card_show/executable.py
+++ b/scenarios/card_show/executable.py
@@ -2,4 +2,4 @@ import balanced
 
 balanced.configure('ak-test-2IuKttETJEorSZLxA9tVbWBIWnRa1kC9P')
 
-card = balanced.Card.find('/cards/CC3q6xpE6zCz8OZTHcXYvHtS')
+card = balanced.Card.get('/cards/CC3q6xpE6zCz8OZTHcXYvHtS')

--- a/scenarios/card_show/python.mako
+++ b/scenarios/card_show/python.mako
@@ -1,9 +1,9 @@
 % if mode == 'definition':
-balanced.Card().find()
+balanced.Card().get()
 % else:
 import balanced
 
 balanced.configure('ak-test-2IuKttETJEorSZLxA9tVbWBIWnRa1kC9P')
 
-card = balanced.Card.find('/cards/CC3q6xpE6zCz8OZTHcXYvHtS')
+card = balanced.Card.get('/cards/CC3q6xpE6zCz8OZTHcXYvHtS')
 % endif

--- a/scenarios/card_show/request.mako
+++ b/scenarios/card_show/request.mako
@@ -1,4 +1,4 @@
 <%namespace file='/_main.mako' name='main'/>
 <% main.python_boilerplate() %>
 
-card = balanced.Card.find('${request['uri']}')
+card = balanced.Card.get('${request['uri']}')


### PR DESCRIPTION
This was figured out from experimentation with the v1.1 library, so I'm not sure if it's 100% correct.
