### PR TITLE
Edit cancel function to void holds

### DIFF
--- a/balanced/resources.py
+++ b/balanced/resources.py
@@ -285,7 +285,7 @@ class CardHold(Resource):
     uri_gen = wac.URIGen('/card_holds', '{card_hold}')
 
     def cancel(self):
-        self.is_void = False
+        self.is_void = True
         return self.save()
 
     def capture(self, **kwargs):

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -187,6 +187,7 @@ class BasicUseCases(unittest.TestCase):
         hold = card.hold(amount=1500, description='Hold me')
         self.assertEqual(hold.description, 'Hold me')
         hold.cancel()
+        self.assertIsNotNone(hold.voided_at)
 
     def test_create_hold_and_capture_it(self):
         card = balanced.Card(**CARD).save()


### PR DESCRIPTION
https://docs.balancedpayments.com/1.1/api/card-holds/#void-a-card-hold wasn't actually working for the python library. The holds object voided_at would just return as null when you called cancel. 
