### PR TITLE
docs: fix simple typo, resouce -> resource

### DIFF
--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -695,7 +695,7 @@ class Rev0URIBasicUseCases(unittest.TestCase):
             yield pattern.format(**args)
 
     def assert_not_rev0(self, resource):
-        """Ensures the given resouce is not in revision 0 format
+        """Ensures the given resource is not in revision 0 format
 
         """
         self.assert_(not hasattr(resource, '_uris'))


### PR DESCRIPTION
There is a small typo in tests/test_suite.py.

Should read `resource` rather than `resouce`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md